### PR TITLE
Context Binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ More tests are missing.
 3. Only interact with externalized state from here on
 
 ```typescript
+import { MobxModel } from "ui5-mobx";
 import { makeAutoObservable } from "mobx";
 
 export default class MobxMainController extends BaseController {
@@ -49,7 +50,6 @@ export default class MobxMainController extends BaseController {
     // 4. manipulate state => it will result in a view change
     people.push({firstName: "Heinz", lastName: "Tester"});
   }
-
 
 }
 ```

--- a/src/cpro/js/ui5/mobx/MobxContextBinding.ts
+++ b/src/cpro/js/ui5/mobx/MobxContextBinding.ts
@@ -26,4 +26,19 @@ export class MobxContextBinding extends ContextBinding {
     // @ts-ignore
     return this.oContext;
   }
+
+  public initialize() {
+    //recreate Context: force update
+    this.oModel.createBindingContext(
+      this.path,
+      this.context,
+      this.mParameters,
+      (context: Context) => {
+        // @ts-ignore: not typed
+        this.oElementContext = context;
+        this._fireChange();
+      },
+      true
+    );
+  }
 }


### PR DESCRIPTION
Hey @texttechne,

I was the one sitting right behind Gregor at UI5 Con nodding at the annotations not working for UI5 😄. I've had a look into the context binding and _might_ have a fix for it, though I'm not sure what else might be missing and it is also not properly typed and no tests written (yet). Basically a small poc for you to check out.

- Added missing import statement in the introductory code sample of the README
- Implemented the initialize function of the `MobxContextBinding`

The `initialize` function is called in UI5 standard [here](https://github.com/SAP/openui5/blob/64427fa20207a28b39cfdf789cd0130b8c1e9cc0/src/sap.ui.core/src/sap/ui/model/ManagedObjectBindingSupport.js#L89) and I've taken the pre-existing implementation from the `ClientContextBinding` [here](https://github.com/SAP/openui5/blob/64427fa20207a28b39cfdf789cd0130b8c1e9cc0/src/sap.ui.core/src/sap/ui/model/ClientContextBinding.js#L62).

The context bindings for the demo below were all done by JS, so using `bindElement`/`bindProperty`. Binding it via the 'binding' of a control also seemed to work though.

![example_mobx_context](https://github.com/cpro-js/ui5-mobx/assets/14982812/1d123e19-4945-43fc-b8e0-fcf1b5dd804a)

From what I've tested so far, context binding a list also seems to work well. I did find a `setContext` usage within `ManagedObjectBindingSupport` but didn't see any usage for the few tests I've done so far. Same with `refresh`. 

Anyway... Binding and especially their implementation aren't my forte so no hard feelings if this is not at all what you were looking for or doesn't help, if that's the case then I'm sorry for wasting your time. ^^

BR,
Marco :) 