### PR TITLE
Add context binding test (rough)

### DIFF
--- a/karma.conf.ts
+++ b/karma.conf.ts
@@ -31,6 +31,7 @@ export default function (config: ConfigWithUi5) {
         "cpro/js/ui5/mobx/test/MobxModelBasics.test",
         "cpro/js/ui5/mobx/test/MobxModelPropertyBinding.test",
         "cpro/js/ui5/mobx/test/MobxModelListBinding.test",
+        "cpro/js/ui5/mobx/test/MobxModelContextBinding.test",
       ],
     },
     // logLevel: "debug",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "texttechne",
   "main": "dist/resources/index.js",
   "scripts": {
-    "build": "ui5 build --clean-dest",
+    "build": "npm run compile && ui5 build --clean-dest",
     "check-circular-deps": "madge ./src --extensions ts --circular",
     "compile": "tsc",
     "prepare": "husky install",

--- a/src/cpro/js/ui5/mobx/MobxContextBinding.ts
+++ b/src/cpro/js/ui5/mobx/MobxContextBinding.ts
@@ -17,6 +17,11 @@ export class MobxContextBinding extends ContextBinding {
     });
   }
 
+  private get model(): MobxModelType {
+    // @ts-ignore
+    return this.oModel;
+  }
+
   private get path(): string {
     // @ts-ignore
     return this.sPath;
@@ -27,15 +32,21 @@ export class MobxContextBinding extends ContextBinding {
     return this.oContext;
   }
 
+  private get parameters(): object {
+    // @ts-ignore
+    return this.mParameters;
+  }
+
   public initialize() {
     //recreate Context: force update
-    this.oModel.createBindingContext(
+    this.model.createBindingContext(
       this.path,
       this.context,
-      this.mParameters,
+      this.parameters,
       (context: Context) => {
         // @ts-ignore: not typed
         this.oElementContext = context;
+        // @ts-ignore: not typed
         this._fireChange();
       },
       true

--- a/src/cpro/js/ui5/mobx/MobxModel.ts
+++ b/src/cpro/js/ui5/mobx/MobxModel.ts
@@ -53,7 +53,7 @@ export class MobxModel<T extends object> extends Model implements MobxModelType<
   }
 
   /**
-   * TODO: JSONModel provides for merge option. Needed?
+   * JSONModel also provides for merge option. However, we don't need that.
    *
    * @param observable
    */

--- a/src/cpro/js/ui5/mobx/MobxModel.ts
+++ b/src/cpro/js/ui5/mobx/MobxModel.ts
@@ -157,6 +157,9 @@ export class MobxModel<T extends object> extends Model implements MobxModelType<
     if (!path) {
       throw new Error(`Path is required! Provided value: ${path}`);
     }
+    if (!ctx) {
+      throw new Error(`Context is required! Provided value: ${ctx}`);
+    }
     return new MobxContextBinding(this, path, ctx, parameters, events);
   }
 

--- a/src/cpro/js/ui5/mobx/MobxModel.ts
+++ b/src/cpro/js/ui5/mobx/MobxModel.ts
@@ -2,7 +2,6 @@ import { MobxContextBinding } from "cpro/js/ui5/mobx/MobxContextBinding";
 import { MobxListBinding } from "cpro/js/ui5/mobx/MobxListBinding";
 import { isObservable } from "mobx";
 import Context from "sap/ui/model/Context";
-import ContextBinding from "sap/ui/model/ContextBinding";
 import Filter from "sap/ui/model/Filter";
 import Model from "sap/ui/model/Model";
 import Sorter from "sap/ui/model/Sorter";
@@ -154,7 +153,7 @@ export class MobxModel<T extends object> extends Model implements MobxModelType<
    */
   public destroyBindingContext(ctx: Context) {}
 
-  public bindContext(path: string, ctx: Context, parameters?: object, events?: object): ContextBinding {
+  public bindContext(path: string, ctx: Context, parameters?: object, events?: object): MobxContextBinding {
     if (!path) {
       throw new Error(`Path is required! Provided value: ${path}`);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export { MobxModel, MobxModelType } from "./cpro/js/ui5/mobx/MobxModel";
 export { MobxPropertyBinding } from "./cpro/js/ui5/mobx/MobxPropertyBinding";
 export { MobxListBinding } from "./cpro/js/ui5/mobx/MobxListBinding";
+export { MobxContextBinding } from "./cpro/js/ui5/mobx/MobxContextBinding";

--- a/test/cpro/js/ui5/mobx/MobxModelBasics.test.ts
+++ b/test/cpro/js/ui5/mobx/MobxModelBasics.test.ts
@@ -30,7 +30,7 @@ describe("MobxModel Tests", () => {
       truth: true,
       text: "ho",
       list: [],
-      complex: { a: "z", b: "y" },
+      complex: { a: "z", b: "y", list: [] },
       listOfComplex: [],
     };
     model.setData(observable(newData));

--- a/test/cpro/js/ui5/mobx/MobxModelContextBinding.test.ts
+++ b/test/cpro/js/ui5/mobx/MobxModelContextBinding.test.ts
@@ -1,0 +1,48 @@
+import { MobxContextBinding } from "cpro/js/ui5/mobx/MobxContextBinding";
+import { MobxModel } from "cpro/js/ui5/mobx/MobxModel";
+import { observable } from "mobx";
+import Context from "sap/ui/model/Context";
+
+import { TestState, createTestData } from "./test-infra/TestHelper";
+
+describe("MobxModel Tests: Context Binding", () => {
+  let state: TestState;
+  let model: MobxModel<TestState>;
+  let binding: MobxContextBinding;
+  let ctx: Context;
+
+  const NEW_VALUE = "one to bind them all";
+
+  beforeEach(() => {
+    state = observable(createTestData());
+    model = new MobxModel(state);
+    ctx = new Context(model, "/complex");
+    binding = model.bindContext("a", ctx);
+  });
+
+  it("smoke test", () => {
+    expect(binding.getModel()).toBe(model);
+    expect(binding.getBoundContext()).not.toBeNull();
+  });
+
+  it("fail without path", () => {
+    expect(() => model.bindContext("", ctx)).toThrowError("Path is required! Provided value: ");
+  });
+
+  it("changing state changes binding", () => {
+    // when changing the value
+    state.complex.a = NEW_VALUE;
+
+    // then value of binding changed both in the context
+    // and the bound context (the value behind 'a')
+    expect(binding.getContext().getProperty("a")).toBe(NEW_VALUE);
+    expect(binding.getBoundContext()!.getProperty("")).toBe(NEW_VALUE);
+  });
+
+  // unsure if testing it the other way around would make sense
+  // it("contextBinding: changing binding changes state", () => {
+  //   // not resolved => returns proxy object, instead of direct value 'a'
+  //   (binding.getContext().getObject() as TestState["complex"]).a = NEW_VALUE;
+  //   expect(state.complex.a).toBe(NEW_VALUE);
+  // });
+});

--- a/test/cpro/js/ui5/mobx/MobxModelContextBinding.test.ts
+++ b/test/cpro/js/ui5/mobx/MobxModelContextBinding.test.ts
@@ -16,19 +16,21 @@ describe("MobxModel Tests: Context Binding", () => {
   beforeEach(() => {
     state = observable(createTestData());
     model = new MobxModel(state);
-    binding = model.bindContext("complex", new Context(model,""));
+    binding = model.bindContext("complex", new Context(model, ""));
     ctx = binding.getBoundContext()!;
   });
 
   it("createBindingContext", () => {
     expect(model.createBindingContext("")).toBeNull();
 
-    ctx = model.createBindingContext("", new Context(model, ""))!
+    ctx = model.createBindingContext("", new Context(model, ""))!;
     expect(ctx.getPath()).toBe("/");
     expect(ctx.getModel()).toBe(model);
-  })
+  });
 
   it("base tests", () => {
+    expect(binding.getPath()).toBe("complex");
+    expect(binding.getResolvedPath()).toBe("/complex");
     expect(binding.getModel()).toBe(model);
     expect(binding.getContext().getPath()).toEqual("");
     expect(ctx.getPath()).toEqual("/complex");
@@ -40,10 +42,29 @@ describe("MobxModel Tests: Context Binding", () => {
 
   it("fail without path", () => {
     expect(() => model.bindContext("", ctx)).toThrowError("Path is required! Provided value: ");
-    // @ts-expect-error: null is not allowed
+    // @ts-expect-error
     expect(() => model.bindContext(null, ctx)).toThrowError("Path is required! Provided value: null");
-    // @ts-expect-error: undefined is not allowed
+    // @ts-expect-error
     expect(() => model.bindContext(undefined, ctx)).toThrowError("Path is required! Provided value: undefined");
+  });
+
+  it("with wrong path", () => {
+    const nonPath = "xxx DoesntExist xxx";
+    const b = model.bindContext(nonPath, new Context(model, ""));
+
+    expect(b.getPath()).toBe(nonPath);
+    expect(b.getBoundContext()!.getProperty("xxx")).toBeNull();
+  });
+
+  it("fail without context", () => {
+    // @ts-expect-error
+    expect(() => model.bindContext("complex")).toThrowError("Context is required! Provided value: undefined");
+    // @ts-expect-error
+    expect(() => model.bindContext("complex", undefined)).toThrowError(
+      "Context is required! Provided value: undefined"
+    );
+    // @ts-expect-error
+    expect(() => model.bindContext("complex", null)).toThrowError("Context is required! Provided value: null");
   });
 
   it("works with propertyBinding", () => {
@@ -52,7 +73,7 @@ describe("MobxModel Tests: Context Binding", () => {
 
     // then we get a value
     expect(propBinding.getValue()).toBe(state.complex.a);
-  })
+  });
 
   it("works with listBinding", () => {
     // when using bound context with list binding
@@ -60,7 +81,7 @@ describe("MobxModel Tests: Context Binding", () => {
 
     // then we get a value
     expect(listBinding.getCount()).toBe(state.complex.list.length);
-  })
+  });
 
   it("changing state changes property binding", () => {
     // given a property binding
@@ -108,5 +129,4 @@ describe("MobxModel Tests: Context Binding", () => {
     // then state changed
     expect(state.complex.list).toEqual([]);
   });
-
 });

--- a/test/cpro/js/ui5/mobx/MobxModelListBinding.test.ts
+++ b/test/cpro/js/ui5/mobx/MobxModelListBinding.test.ts
@@ -27,13 +27,24 @@ describe("MobxModel Tests: List Binding", () => {
     binding = model.bindList("/listOfComplex");
   });
 
-  it("smoke test", () => {
-    expect(binding.getLength()).toBe(state.listOfComplex.length);
+  it("test basics", () => {
     expect(binding.getModel()).toBe(model);
+    expect(binding.getContext()).toBeUndefined();
+    expect(binding.getLength()).toBe(state.listOfComplex.length);
+    expect(binding.getCount()).toBe(state.listOfComplex.length);
+    expect(binding.getData()).toBe(state.listOfComplex);
+    expect(binding.getContexts().length).toBe(2);
+    expect(binding.getContexts()[0].toString()).toBe("/listOfComplex/0");
   });
 
   it("fail without path", () => {
     expect(() => model.bindList("")).toThrowError("Path is required! Provided value: ");
+    // @ts-expect-error
+    expect(() => model.bindList(null)).toThrowError("Path is required! Provided value: null");
+    // @ts-expect-error
+    expect(() => model.bindList(undefined)).toThrowError("Path is required! Provided value: undefined");
+    // @ts-expect-error
+    expect(() => model.bindList()).toThrowError("Path is required! Provided value: undefined");
   });
 
   it("changing state changes binding", () => {
@@ -64,9 +75,25 @@ describe("MobxModel Tests: List Binding", () => {
     expect(spy.called).toBeFalse();
   });
 
-  it("propertyBinding: changing binding changes state", () => {
+  it("changing binding changes state", () => {
     binding.setValue(NEW_VALUE);
 
     expect(state.listOfComplex).toEqual(NEW_VALUE);
   });
+
+  it("using property binding", () => {
+    const propBinding = model.bindProperty("a", binding.getContexts()[0])
+
+    expect(propBinding.getPath()).toBe("a")
+    expect(propBinding.getValue()).toBe("a")
+
+    // change via binding
+    propBinding.setValue("z")
+    expect(state.listOfComplex[0].a).toEqual("z");
+
+    // change via state
+    state.listOfComplex[0].a = "b";
+    expect(state.listOfComplex[0].a).toEqual("b");
+  });
+
 });

--- a/test/cpro/js/ui5/mobx/MobxModelPropertyBinding.test.ts
+++ b/test/cpro/js/ui5/mobx/MobxModelPropertyBinding.test.ts
@@ -44,8 +44,6 @@ describe("MobxModel Tests: Property Binding", () => {
   });
 
   it("propertyBinding: changing binding changes state", () => {
-    const binding = model.bindProperty("/text");
-
     binding.setValue(NEW_VALUE);
 
     expect(state.text).toBe(NEW_VALUE);

--- a/test/cpro/js/ui5/mobx/MobxModelPropertyBinding.test.ts
+++ b/test/cpro/js/ui5/mobx/MobxModelPropertyBinding.test.ts
@@ -2,7 +2,6 @@ import { MobxModel } from "cpro/js/ui5/mobx/MobxModel";
 import { observable } from "mobx";
 import ChangeReason from "sap/ui/model/ChangeReason";
 import PropertyBinding from "sap/ui/model/PropertyBinding";
-
 import { TestState, createTestData } from "./test-infra/TestHelper";
 
 describe("MobxModel Tests: Property Binding", () => {
@@ -18,12 +17,19 @@ describe("MobxModel Tests: Property Binding", () => {
     binding = model.bindProperty("/text");
   });
 
-  it("smoke test", () => {
+  it("simple successful path", () => {
+    expect(binding.getValue()).toBe("test");
     expect(binding.getValue()).toBe(state.text);
   });
 
   it("fail without path", () => {
     expect(() => model.bindProperty("")).toThrowError("Path is required! Provided value: ");
+    // @ts-expect-error
+    expect(() => model.bindProperty(null)).toThrowError("Path is required! Provided value: null");
+    // @ts-expect-error
+    expect(() => model.bindProperty(undefined)).toThrowError("Path is required! Provided value: undefined");
+    // @ts-expect-error
+    expect(() => model.bindProperty()).toThrowError("Path is required! Provided value: undefined");
   });
 
   it("changing state changes binding", () => {

--- a/test/cpro/js/ui5/mobx/test-infra/TestHelper.ts
+++ b/test/cpro/js/ui5/mobx/test-infra/TestHelper.ts
@@ -7,6 +7,16 @@ const TEST_DATA = {
   complex: {
     a: "a",
     b: "b",
+    list: [
+      {
+        a: "a",
+        b: "b",
+      },
+      {
+        c: "c",
+        d: "d",
+      }
+    ]
   },
   listOfComplex: [
     {


### PR DESCRIPTION
Hi @texttechne,

I have tried to come up with tests based on pre-existing ones but I'm having a hard time coming into the right mindset for testing. I'm not that good in writing tests, even more so when it comes to such "internals" like the context. 

Maybe we can work on that one together(?) and simply have this PR open until it's ready. =)

Additionally I [adjusted the bindContext return type](https://github.com/cpro-js/ui5-mobx/compare/main...wridgeu:feat/add-test?expand=1#diff-a9ea1396d72bad2bce45c77421d9aece5cd05bac1596b76fae46620039670dd8R156) to match what is returned and removed an unnecessary [bindProperty](https://github.com/cpro-js/ui5-mobx/compare/main...wridgeu:feat/add-test?expand=1#diff-e9bb8753f781096a07541d83b2e5474099b9e41d6b354d6fe78cd1977f403a8aL47) call, as it is done within "beforeEach" of the test.

BR, Marco